### PR TITLE
add certificates table, model and persistence in certificate generation

### DIFF
--- a/app/Models/Certificate.php
+++ b/app/Models/Certificate.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Certificate extends Model
+{
+    protected $fillable = [
+        'event_id',
+        'participant_id',
+        'ref',
+        'issued_at',
+    ];
+
+    protected $casts = [
+        'issued_at' => 'datetime',
+    ];
+
+    public function event()
+    {
+        return $this->belongsTo(\App\Models\Event::class);
+    }
+
+    public function participant()
+    {
+        return $this->belongsTo(\App\Models\Participant::class);
+    }
+}

--- a/database/migrations/2025_09_04_183704_create_certificates_table.php
+++ b/database/migrations/2025_09_04_183704_create_certificates_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::create('certificates', function (Blueprint $table) {
+            $table->id();
+
+            $table->foreignId('event_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('participant_id')->constrained()->cascadeOnDelete();
+
+            $table->string('ref')->unique(); // código de verificação/autenticidade
+            $table->timestamp('issued_at');
+
+            $table->timestamps();
+
+            $table->unique(['event_id','participant_id']); // 1 cert por participante+evento
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('certificates');
+    }
+};


### PR DESCRIPTION
> Criação da Tabela e Model Certificates
* Criada migration para a tabela certificates com os campos:
    * id (PK)
    * event_id (FK → events.id)
    * participant_id (FK → participants.id)
    * ref (código único para autenticidade)
    * issued_at (datetime de emissão)
    * created_at / updated_at
* Criado o model Certificate com relacionamentos:
    * belongsTo(Event::class)
    * belongsTo(Participant::class)

> Ajustes no CertificateController
* Adicionada verificação para garantir que o participante pertence ao evento antes de gerar certificado.
* Implementado uso do Certificate::firstOrCreate(), criando ou recuperando certificado existente para o par evento + participante.
* Código ref gerado automaticamente via Str::random(12) no momento da criação.
* issued_at preenchido com data/hora atual.
* PDF agora é gerado com base nos dados persistidos na tabela certificates.

> Ajustes no Fluxo de Geração de Certificados
* Ao gerar certificado, se já existir, reutiliza-se o mesmo ref e issued_at.
* Caso não exista, um novo registro é criado automaticamente.
* Evita geração duplicada para o mesmo participante/evento.