### PR TITLE
classe, botões, rotas e funcoes para enviar o certificado por email

### DIFF
--- a/app/Mail/CertificateMail.php
+++ b/app/Mail/CertificateMail.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Mail;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Mail\Mailable;
+use Illuminate\Mail\Mailables\Content;
+use Illuminate\Mail\Mailables\Envelope;
+use Illuminate\Queue\SerializesModels;
+
+class CertificateMail extends Mailable
+{
+    use Queueable, SerializesModels;
+
+    public $pdf;
+    public $name;
+
+    /**
+     * Create a new message instance.
+     */
+    public function __construct($pdf, $name)
+    {
+        $this->pdf = $pdf;
+        $this->name = $name;
+    }
+
+    public function build()
+    {
+        return $this->subject('Seu Certificado')
+            ->view('emails.certificate')
+            ->attachData(
+                $this->pdf, "certificate-{$this->name}.pdf", [
+                'mime' => 'application/pdf',
+            ]);
+    }
+
+
+
+}

--- a/composer.json
+++ b/composer.json
@@ -7,6 +7,7 @@
     "license": "MIT",
     "require": {
         "php": "^8.2",
+        "barryvdh/laravel-dompdf": "^3.1",
         "laravel/framework": "^12.0",
         "laravel/tinker": "^2.10.1",
         "spatie/laravel-pdf": "^1.7"

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,85 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "6adb7a269111c6ef8bc02330c1de4497",
+    "content-hash": "8295901dadee7ee0fd14c8bcb9ab05f5",
     "packages": [
+        {
+            "name": "barryvdh/laravel-dompdf",
+            "version": "v3.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/barryvdh/laravel-dompdf.git",
+                "reference": "8e71b99fc53bb8eb77f316c3c452dd74ab7cb25d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/barryvdh/laravel-dompdf/zipball/8e71b99fc53bb8eb77f316c3c452dd74ab7cb25d",
+                "reference": "8e71b99fc53bb8eb77f316c3c452dd74ab7cb25d",
+                "shasum": ""
+            },
+            "require": {
+                "dompdf/dompdf": "^3.0",
+                "illuminate/support": "^9|^10|^11|^12",
+                "php": "^8.1"
+            },
+            "require-dev": {
+                "larastan/larastan": "^2.7|^3.0",
+                "orchestra/testbench": "^7|^8|^9|^10",
+                "phpro/grumphp": "^2.5",
+                "squizlabs/php_codesniffer": "^3.5"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "aliases": {
+                        "PDF": "Barryvdh\\DomPDF\\Facade\\Pdf",
+                        "Pdf": "Barryvdh\\DomPDF\\Facade\\Pdf"
+                    },
+                    "providers": [
+                        "Barryvdh\\DomPDF\\ServiceProvider"
+                    ]
+                },
+                "branch-alias": {
+                    "dev-master": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Barryvdh\\DomPDF\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Barry vd. Heuvel",
+                    "email": "barryvdh@gmail.com"
+                }
+            ],
+            "description": "A DOMPDF Wrapper for Laravel",
+            "keywords": [
+                "dompdf",
+                "laravel",
+                "pdf"
+            ],
+            "support": {
+                "issues": "https://github.com/barryvdh/laravel-dompdf/issues",
+                "source": "https://github.com/barryvdh/laravel-dompdf/tree/v3.1.1"
+            },
+            "funding": [
+                {
+                    "url": "https://fruitcake.nl",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/barryvdh",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-02-13T15:07:54+00:00"
+        },
         {
             "name": "brick/math",
             "version": "0.13.1",
@@ -376,6 +453,161 @@
                 }
             ],
             "time": "2024-02-05T11:56:58+00:00"
+        },
+        {
+            "name": "dompdf/dompdf",
+            "version": "v3.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/dompdf/dompdf.git",
+                "reference": "a51bd7a063a65499446919286fb18b518177155a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/dompdf/dompdf/zipball/a51bd7a063a65499446919286fb18b518177155a",
+                "reference": "a51bd7a063a65499446919286fb18b518177155a",
+                "shasum": ""
+            },
+            "require": {
+                "dompdf/php-font-lib": "^1.0.0",
+                "dompdf/php-svg-lib": "^1.0.0",
+                "ext-dom": "*",
+                "ext-mbstring": "*",
+                "masterminds/html5": "^2.0",
+                "php": "^7.1 || ^8.0"
+            },
+            "require-dev": {
+                "ext-gd": "*",
+                "ext-json": "*",
+                "ext-zip": "*",
+                "mockery/mockery": "^1.3",
+                "phpunit/phpunit": "^7.5 || ^8 || ^9 || ^10 || ^11",
+                "squizlabs/php_codesniffer": "^3.5",
+                "symfony/process": "^4.4 || ^5.4 || ^6.2 || ^7.0"
+            },
+            "suggest": {
+                "ext-gd": "Needed to process images",
+                "ext-gmagick": "Improves image processing performance",
+                "ext-imagick": "Improves image processing performance",
+                "ext-zlib": "Needed for pdf stream compression"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Dompdf\\": "src/"
+                },
+                "classmap": [
+                    "lib/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-2.1"
+            ],
+            "authors": [
+                {
+                    "name": "The Dompdf Community",
+                    "homepage": "https://github.com/dompdf/dompdf/blob/master/AUTHORS.md"
+                }
+            ],
+            "description": "DOMPDF is a CSS 2.1 compliant HTML to PDF converter",
+            "homepage": "https://github.com/dompdf/dompdf",
+            "support": {
+                "issues": "https://github.com/dompdf/dompdf/issues",
+                "source": "https://github.com/dompdf/dompdf/tree/v3.1.0"
+            },
+            "time": "2025-01-15T14:09:04+00:00"
+        },
+        {
+            "name": "dompdf/php-font-lib",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/dompdf/php-font-lib.git",
+                "reference": "6137b7d4232b7f16c882c75e4ca3991dbcf6fe2d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/dompdf/php-font-lib/zipball/6137b7d4232b7f16c882c75e4ca3991dbcf6fe2d",
+                "reference": "6137b7d4232b7f16c882c75e4ca3991dbcf6fe2d",
+                "shasum": ""
+            },
+            "require": {
+                "ext-mbstring": "*",
+                "php": "^7.1 || ^8.0"
+            },
+            "require-dev": {
+                "symfony/phpunit-bridge": "^3 || ^4 || ^5 || ^6"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "FontLib\\": "src/FontLib"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-2.1-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "The FontLib Community",
+                    "homepage": "https://github.com/dompdf/php-font-lib/blob/master/AUTHORS.md"
+                }
+            ],
+            "description": "A library to read, parse, export and make subsets of different types of font files.",
+            "homepage": "https://github.com/dompdf/php-font-lib",
+            "support": {
+                "issues": "https://github.com/dompdf/php-font-lib/issues",
+                "source": "https://github.com/dompdf/php-font-lib/tree/1.0.1"
+            },
+            "time": "2024-12-02T14:37:59+00:00"
+        },
+        {
+            "name": "dompdf/php-svg-lib",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/dompdf/php-svg-lib.git",
+                "reference": "eb045e518185298eb6ff8d80d0d0c6b17aecd9af"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/dompdf/php-svg-lib/zipball/eb045e518185298eb6ff8d80d0d0c6b17aecd9af",
+                "reference": "eb045e518185298eb6ff8d80d0d0c6b17aecd9af",
+                "shasum": ""
+            },
+            "require": {
+                "ext-mbstring": "*",
+                "php": "^7.1 || ^8.0",
+                "sabberworm/php-css-parser": "^8.4"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^7.5 || ^8.5 || ^9.5"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Svg\\": "src/Svg"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-3.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "The SvgLib Community",
+                    "homepage": "https://github.com/dompdf/php-svg-lib/blob/master/AUTHORS.md"
+                }
+            ],
+            "description": "A library to read, parse and export to PDF SVG files.",
+            "homepage": "https://github.com/dompdf/php-svg-lib",
+            "support": {
+                "issues": "https://github.com/dompdf/php-svg-lib/issues",
+                "source": "https://github.com/dompdf/php-svg-lib/tree/1.0.0"
+            },
+            "time": "2024-04-29T13:26:35+00:00"
         },
         {
             "name": "dragonmantank/cron-expression",
@@ -2008,6 +2240,73 @@
             "time": "2024-12-08T08:18:47+00:00"
         },
         {
+            "name": "masterminds/html5",
+            "version": "2.10.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Masterminds/html5-php.git",
+                "reference": "fcf91eb64359852f00d921887b219479b4f21251"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Masterminds/html5-php/zipball/fcf91eb64359852f00d921887b219479b4f21251",
+                "reference": "fcf91eb64359852f00d921887b219479b4f21251",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "php": ">=5.3.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.8.35 || ^5.7.21 || ^6 || ^7 || ^8 || ^9"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.7-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Masterminds\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Matt Butcher",
+                    "email": "technosophos@gmail.com"
+                },
+                {
+                    "name": "Matt Farina",
+                    "email": "matt@mattfarina.com"
+                },
+                {
+                    "name": "Asmir Mustafic",
+                    "email": "goetas@gmail.com"
+                }
+            ],
+            "description": "An HTML5 parser and serializer.",
+            "homepage": "http://masterminds.github.io/html5-php",
+            "keywords": [
+                "HTML5",
+                "dom",
+                "html",
+                "parser",
+                "querypath",
+                "serializer",
+                "xml"
+            ],
+            "support": {
+                "issues": "https://github.com/Masterminds/html5-php/issues",
+                "source": "https://github.com/Masterminds/html5-php/tree/2.10.0"
+            },
+            "time": "2025-07-25T09:04:22+00:00"
+        },
+        {
             "name": "monolog/monolog",
             "version": "3.9.0",
             "source": {
@@ -3273,6 +3572,72 @@
                 "source": "https://github.com/ramsey/uuid/tree/4.9.0"
             },
             "time": "2025-06-25T14:20:11+00:00"
+        },
+        {
+            "name": "sabberworm/php-css-parser",
+            "version": "v8.9.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/MyIntervals/PHP-CSS-Parser.git",
+                "reference": "d8e916507b88e389e26d4ab03c904a082aa66bb9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/MyIntervals/PHP-CSS-Parser/zipball/d8e916507b88e389e26d4ab03c904a082aa66bb9",
+                "reference": "d8e916507b88e389e26d4ab03c904a082aa66bb9",
+                "shasum": ""
+            },
+            "require": {
+                "ext-iconv": "*",
+                "php": "^5.6.20 || ^7.0.0 || ~8.0.0 || ~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "5.7.27 || 6.5.14 || 7.5.20 || 8.5.41",
+                "rawr/cross-data-providers": "^2.0.0"
+            },
+            "suggest": {
+                "ext-mbstring": "for parsing UTF-8 CSS"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "9.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Sabberworm\\CSS\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Raphael Schweikert"
+                },
+                {
+                    "name": "Oliver Klee",
+                    "email": "github@oliverklee.de"
+                },
+                {
+                    "name": "Jake Hotson",
+                    "email": "jake.github@qzdesign.co.uk"
+                }
+            ],
+            "description": "Parser for CSS Files written in PHP",
+            "homepage": "https://www.sabberworm.com/blog/2010/6/10/php-css-parser",
+            "keywords": [
+                "css",
+                "parser",
+                "stylesheet"
+            ],
+            "support": {
+                "issues": "https://github.com/MyIntervals/PHP-CSS-Parser/issues",
+                "source": "https://github.com/MyIntervals/PHP-CSS-Parser/tree/v8.9.0"
+            },
+            "time": "2025-07-11T13:20:48+00:00"
         },
         {
             "name": "spatie/browsershot",

--- a/resources/js/certificates.js
+++ b/resources/js/certificates.js
@@ -1,0 +1,49 @@
+
+
+// js para preencher automaticamente os campos do formulario do email na blade participants/view-edit-participants.blade.php
+document.addEventListener("DOMContentLoaded", () => {
+    const emailButtons = document.querySelectorAll("[data-cert-email]");
+
+    if (emailButtons.length) {
+        emailButtons.forEach(btn => {
+            btn.addEventListener("click", () => {
+                const name = btn.dataset.participantName;
+                const email = btn.dataset.participantEmail;
+                const course = "Curso X"; // or fetch dynamically
+                const date = new Date().toISOString().slice(0, 10); // today
+
+                const form = document.getElementById("certificate-email-form");
+                form.querySelector("[name='name']").value = name;
+                form.querySelector("[name='email']").value = email;
+                form.querySelector("[name='course']").value = course;
+                form.querySelector("[name='date']").value = date;
+
+                form.submit();
+            });
+        });
+    }
+});
+
+
+
+// js para preencher automaticamente os campos do formulario do email com os valores dos campos do formulario do certificado (na blade certificates/custom.blade.php)
+document.addEventListener("DOMContentLoaded", () => {
+    const downloadForm = document.querySelector('form[action*="certificates.download.custom"]');
+    const emailForm = document.querySelector('form[action*="certificates.send.custom"]');
+
+    if (downloadForm && emailForm) {
+        // Sync all inputs by their name
+        downloadForm.querySelectorAll("input").forEach(input => {
+            input.addEventListener("input", () => {
+                const target = emailForm.querySelector(`[name="${input.name}"]`);
+                if (target) {
+                    target.value = input.value;
+                }
+            });
+        });
+    }
+});
+
+
+
+

--- a/resources/views/certificates/custom.blade.php
+++ b/resources/views/certificates/custom.blade.php
@@ -1,4 +1,7 @@
 <x-app-layout>
+
+    @vite(['resources/js/certificates.js'])
+
     <x-slot name="header">
         <div class="flex items-center justify-between">
             <h2 class="font-semibold text-xl text-gray-800 leading-tight">
@@ -7,23 +10,24 @@
         </div>
     </x-slot>
 
-    <div class="p-6">
-        <form action="{{ route('certificates.download.custom') }}" method="GET" class="space-y-4">
+    <div class="p-6 space-y-6">
+        <!-- Download Form -->
+        <form id="downloadForm" action="{{ route('certificates.download.custom') }}" method="GET" class="space-y-4">
             @csrf
 
             <div>
                 <label class="block font-medium">Nome</label>
-                <input type="text" name="name" class="border rounded w-full p-2" placeholder="Nome do participante" required>
+                <input type="text" id="name" name="name" class="border rounded w-full p-2" placeholder="Nome do participante" required>
             </div>
 
             <div>
                 <label class="block font-medium">Curso/Programa</label>
-                <input type="text" name="course" class="border rounded w-full p-2" placeholder="Nome do curso" required>
+                <input type="text" id="course" name="course" class="border rounded w-full p-2" placeholder="Nome do curso" required>
             </div>
 
             <div>
                 <label class="block font-medium">Data</label>
-                <input type="date" name="date" class="border rounded w-full p-2" required>
+                <input type="date" id="date" name="date" class="border rounded w-full p-2" required>
             </div>
 
             <div>
@@ -32,5 +36,27 @@
                 </button>
             </div>
         </form>
+
+        <!-- Send Email Form -->
+        <form id="emailForm" action="{{ route('certificates.send.custom') }}" method="POST" class="space-y-4">
+            @csrf
+
+            <div>
+                <label class="block font-medium">Email do destinatário</label>
+                <input type="email" id="email" name="email" class="border rounded w-full p-2" placeholder="Digite o email do participante" required>
+            </div>
+
+            <!-- Hidden inputs that will be auto-filled with javascrip (to copy the custom form’s fields into the email form automatically) -->
+            <input type="hidden" id="email_name" name="name">
+            <input type="hidden" id="email_course" name="course">
+            <input type="hidden" id="email_date" name="date">
+
+            <div>
+                <button type="submit" class="px-4 py-2 bg-green-600 text-white rounded hover:bg-green-700">
+                    Enviar certificado por email
+                </button>
+            </div>
+        </form>
     </div>
+
 </x-app-layout>

--- a/resources/views/emails/certificate.blade.php
+++ b/resources/views/emails/certificate.blade.php
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>Seu Certificado</title>
+</head>
+<body>
+    <p>Olá {{ $name }},</p>
+    <p>Segue anexo o seu certificado.</p>
+    <p>Obrigado!</p>
+</body>
+</html>

--- a/resources/views/participants/view-edit-participants.blade.php
+++ b/resources/views/participants/view-edit-participants.blade.php
@@ -1,4 +1,7 @@
 <x-app-layout>
+
+    @vite(['resources/js/certificates.js'])
+
     <x-slot name="header">
         <div class="flex items-center justify-between">
             <h2 class="font-semibold text-xl text-gray-800 leading-tight">
@@ -65,20 +68,51 @@
                                         </form>
                                     </td>
 
-                                    <!-- Generate Certificates buttons/routes -->
-                                    <td class="py-2">
-                                        <button></button>
+                                    <!-- Certificate Buttons -->
+                                    <td class="py-2 flex gap-2">
+
+                                        <!-- Download certificate  -->
                                         <a href="{{ route('certificates.download', [$event->id, $participant->id]) }}">
                                             <button class="px-3 py-1 bg-blue-500 text-white rounded hover:bg-blue-600">
                                                 Baixar certificado
                                             </button>
                                         </a>
+
+                                        <!-- Send certificate by email (uses js) -->
+                                        <!-- Obs: data-cert-email is a custom HTML attribute, often called a data- attribute.
+                                            In HTML5, you can define custom attributes that start with data- to store extra
+                                            information on html elements. The browser ignores them by default,
+                                            but JavaScript can read them easily. -->
+                                        <button
+                                            type="button"
+                                            class="px-3 py-1 bg-blue-500 text-white rounded hover:bg-blue-600"
+                                            data-cert-email
+                                            data-participant-id="{{ $participant->id }}"
+                                            data-participant-name="{{ $participant->name }}"
+                                            data-participant-email="{{ $participant->email }}"
+                                            data-event-id="{{ $event->id }}"
+                                            data-event-title="{{ $event->title }}"
+                                        >
+                                            <svg xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 -960 960 960" width="24px" fill="#1f1f1f"><path d="M160-160q-33 0-56.5-23.5T80-240v-480q0-33 23.5-56.5T160-800h640q33 0 56.5 23.5T880-720v480q0 33-23.5 56.5T800-160H160Zm320-280L160-640v400h640v-400L480-440Zm0-80 320-200H160l320 200ZM160-640v-80 480-400Z"/></svg>
+                                        </button>
+
                                     </td>
+
 
                                 </tr>
                             @endforeach
                         </tbody>
                     </table>
+
+                    <!-- Hidden form for sending certificate by email -->
+                    <form id="certificate-email-form" action="{{ route('certificates.send') }}" method="POST" style="display:none;">
+                        @csrf
+                        <input type="hidden" name="name">
+                        <input type="hidden" name="course" value="Course">
+                        <input type="hidden" name="date" value="{{ date('Y-m-d') }}">
+                        <input type="hidden" name="email">
+                    </form>
+
                 @endif
 
                 <!-- Add Participant Form -->

--- a/routes/web.php
+++ b/routes/web.php
@@ -55,12 +55,18 @@ Route::middleware(['auth', 'role:admin,staff'])->group(function () {
 
     // Rotas de certificados
 
-    // Custom/Blank form routes
+    // Custom certificate form routes
     Route::get('/certificates/custom', [CertificateController::class, 'custom'])->name('certificates.custom');
     Route::get('/certificates/download-custom', [CertificateController::class, 'certificateDownloadCustom'])->name('certificates.download.custom');
 
-    // Event/participant route
+    // Event/participant certificate route
     Route::get('/certificates/download/{event}/{participant}', [CertificateController::class, 'certificateDownload'])->name('certificates.download');
+
+    // send certificate pdf by email routes
+    Route::post('/certificates/send', [CertificateController::class, 'sendCertificate'])->name('certificates.send');
+    Route::post('/certificates/send/custom', [CertificateController::class, 'sendCustom'])->name('certificates.send.custom');
+
+
 
 
 });


### PR DESCRIPTION
A classe CertificateMail (e seus atributos e função build()), os botoes "enviar por email" nas blades certificates/custom.blade.php e participants/view-edit-participant.bçade.php, as rotas certificates.send e certificates.send.custom foram criadas e estão "corretas". As funções sendCertificate() e sendCustom() no CertificateController é que estavam dando problema. Instalei o Dompdf e consegui fazer a função sendCertificate() funcionar . A outra ainda não adaptei para a sintaxe do Dompdf (continua com a sintaxe do Spatie), e antes de mudar tudo para Dompdf acho que podemos tentar fazer fucnionar com o Spatie mais um pouco.