### PR TITLE
feature to share on social medias being implemented

### DIFF
--- a/app/Http/Controllers/PublicCertificateController.php
+++ b/app/Http/Controllers/PublicCertificateController.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Certificate;
+use Illuminate\Support\Facades\Storage;
+
+class PublicCertificateController extends Controller
+{
+    public function show(string $publicId)
+    {
+        $cert = Certificate::with(['event.type', 'participant'])
+            ->where('public_id', $publicId)
+            ->whereNotNull('published_at')
+            ->firstOrFail();
+
+        $event = $cert->event;
+        $participant = $cert->participant;
+
+        // ====== Montagem dos mesmos dados da buildCertificateData ======
+        $eventTypeName   = optional($event->type)->name ?? 'evento';
+        $institutionName = $event->issuer_institution ?: config('app.name');
+        $eventTitle      = $event->title;
+
+        $durationPhrase = null;
+        $h = $event->hours;
+        if (is_numeric($h) && (int)$h > 0) {
+            $h = (int)$h;
+            $durationPhrase = 'com uma carga horária total de ' . $h . ' ' . ($h === 1 ? 'hora' : 'horas');
+        }
+
+        $datePhrase = null;
+        $start = $event->start_at;
+        $end   = $event->end_at;
+        if ($start && $end) {
+            if ($start->isSameDay($end)) {
+                $datePhrase = 'em ' . $end->format('d/m/Y');
+            } else {
+                $datePhrase = 'iniciado em ' . $start->format('d/m/Y') . ' até ' . $end->format('d/m/Y');
+            }
+        }
+
+        // Assinatura (se existir no storage público)
+        $signatureBase64 = null;
+        if (!empty($event->issuer_signature_path) && \Storage::disk('public')->exists($event->issuer_signature_path)) {
+            $absolutePath = \Storage::disk('public')->path($event->issuer_signature_path);
+            $data = @file_get_contents($absolutePath);
+            if ($data !== false) {
+                $mime = function_exists('mime_content_type') ? mime_content_type($absolutePath) : 'image/png';
+                $signatureBase64 = 'data:' . $mime . ';base64,' . base64_encode($data);
+            }
+        }
+
+        $logoBase64 = null; // se tiver, pode popular
+
+        $pdfData = [
+            'name'             => $participant->name,
+            'event_title'      => $eventTitle,
+            'event_type_name'  => $eventTypeName,
+            'institution_name' => $institutionName,
+            'duration_phrase'  => $durationPhrase,
+            'date_phrase'      => $datePhrase,
+            'ref'              => $cert->ref,
+            'primary_color'    => '#000000',
+            'logoBase64'       => $logoBase64,
+            'signatureBase64'  => $signatureBase64,
+            'signer_name'      => $event->issuer_name,
+            'signer_role'      => $event->issuer_role,
+            'watermark'        => null,
+            'preview_mode'     => true,
+            'public_id'        => $cert->public_id,
+        ];
+
+        return view('certificates.pdf', $pdfData);
+    }
+}

--- a/app/Mail/CertificateMail.php
+++ b/app/Mail/CertificateMail.php
@@ -3,11 +3,9 @@
 namespace App\Mail;
 
 use Illuminate\Bus\Queueable;
-use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Mail\Mailable;
-use Illuminate\Mail\Mailables\Content;
-use Illuminate\Mail\Mailables\Envelope;
 use Illuminate\Queue\SerializesModels;
+use App\Models\Certificate as CertificateModel;
 
 class CertificateMail extends Mailable
 {
@@ -15,26 +13,26 @@ class CertificateMail extends Mailable
 
     public $pdf;
     public $name;
+    public $certificate;
 
-    /**
-     * Create a new message instance.
-     */
-    public function __construct($pdf, $name)
+    public function __construct($pdf, $name, CertificateModel $certificate)
     {
         $this->pdf = $pdf;
         $this->name = $name;
+        $this->certificate = $certificate;
     }
 
     public function build()
     {
+        $publicUrl = route('certificates.public.show', $this->certificate->public_id);
+
         return $this->subject('Seu Certificado')
-            ->view('emails.certificate')
-            ->attachData(
-                $this->pdf, "certificate-{$this->name}.pdf", [
+            ->view('emails.certificate', [
+                'name' => $this->name,
+                'publicUrl' => $publicUrl,
+            ])
+            ->attachData($this->pdf, "certificate-{$this->name}.pdf", [
                 'mime' => 'application/pdf',
             ]);
     }
-
-
-
 }

--- a/database/migrations/2025_09_18_130740_add_public_fields_to_certificates_table.php
+++ b/database/migrations/2025_09_18_130740_add_public_fields_to_certificates_table.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('certificates', function (Blueprint $table) {
+            $table->uuid('public_id')->nullable()->unique()->after('id');
+            $table->timestamp('published_at')->nullable()->after('issued_at');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('certificates', function (Blueprint $table) {
+            $table->dropColumn(['public_id', 'published_at']);
+        });
+    }
+
+};

--- a/resources/views/certificates/pdf.blade.php
+++ b/resources/views/certificates/pdf.blade.php
@@ -3,12 +3,28 @@
 <head>
   <meta charset="UTF-8" />
   <title>Certificado</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+
+  @php
+    // A barra só deve aparecer quando for preview web E houver public_id (página pública).
+    $resolvedPublicId = $public_id ?? request()->route('publicId');
+    $showActionBar = ($preview_mode ?? false) && !empty($resolvedPublicId);
+  @endphp
+
+  {{-- Assets e metas só no modo web (não entram no PDF) --}}
+  @if($preview_mode ?? false)
+    @vite(['resources/css/app.css', 'resources/js/app.js'])
+    <meta property="og:type" content="article">
+    <meta property="og:title" content="Certificado – {{ $name ?? 'Participante' }}">
+    <meta property="og:description" content="{{ $event_title ?? 'Evento' }} • Código: {{ $ref ?? '—' }}">
+    <meta property="og:url" content="{{ url()->current() }}">
+    {{-- <meta property="og:image" content="{{ asset('img/certificate-og-default.jpg') }}"> --}}
+    <meta name="robots" content="noindex, nofollow">
+  @endif
+
   <style>
     /* Página A4 deitada */
-    @page {
-      size: 297mm 210mm;  
-      margin: 0;      
-    }
+    @page { size: 297mm 210mm; margin: 0; }
 
     html, body { margin: 0; padding: 0; }
     body { font-family: DejaVu Sans, Arial, sans-serif; color: #222; }
@@ -19,7 +35,6 @@
     }
 
     /* Moldura */
-
     .frame {
       position: fixed;
       top: 10mm; left: 10mm; right: 10mm; bottom: 10mm;
@@ -30,38 +45,19 @@
     /* ---- Área útil da moldura ---- */
     .content-area {
       position: fixed;
-      top: 25mm; 
-      left: 12mm;
-      right: 12mm;
-      bottom: 13mm; 
+      top: 25mm; left: 12mm; right: 12mm; bottom: 13mm;
       box-sizing: border-box;
     }
 
-    .vcenter {
-      display: table;
-      width: 100%;
-      height: 100%;
-      table-layout: fixed;
-    }
-
-    .vcenter-cell {
-      display: table-cell;
-      vertical-align: middle;
-      text-align: center; 
-      padding: 0 10mm;
-    }
+    .vcenter { display: table; width: 100%; height: 100%; table-layout: fixed; }
+    .vcenter-cell { display: table-cell; vertical-align: middle; text-align: center; padding: 0 10mm; }
 
     /* Watermark  */
     .watermark {
-      position: absolute;
-      top: 50%; left: 50%;
+      position: absolute; top: 50%; left: 50%;
       transform: translate(-50%, -50%);
-      font-size: 72pt;
-      color: var(--primary);
-      opacity: .06;
-      white-space: nowrap;
-      pointer-events: none;
-      
+      font-size: 72pt; color: var(--primary); opacity: .06;
+      white-space: nowrap; pointer-events: none;
     }
 
     /* Cabeçalho / Logo */
@@ -69,238 +65,176 @@
     .logo img { max-height: 14mm; }
 
     /* Títulos e texto */
-    .title {
-      font-size: 20pt;
-      letter-spacing: .5px;
-      margin: 0 0 6mm 0;
-      text-transform: uppercase;
-      color: #111;
-    }
-
-    .subtitle {
-      font-size: 11pt;
-      color: #666;
-      margin: 0 0 6mm 0;
-    }
-
-    .intro {
-      font-size: 11pt;
-      margin: 0 0 4mm 0;
-    }
-
-    .name {
-      font-size: 28pt;
-      font-weight: 700;
-      margin: 2mm 0 6mm 0;
-      line-height: 1.1;
-    }
-
-    .course-line {
-      font-size: 12pt;
-      margin: 0 0 2mm 0;
-    }
-
+    .title { font-size: 20pt; letter-spacing: .5px; margin: 0 0 6mm 0; text-transform: uppercase; color: #111; }
+    .subtitle { font-size: 11pt; color: #666; margin: 0 0 6mm 0; }
+    .intro { font-size: 11pt; margin: 0 0 4mm 0; }
+    .name { font-size: 28pt; font-weight: 700; margin: 2mm 0 6mm 0; line-height: 1.1; }
+    .course-line { font-size: 12pt; margin: 0 0 2mm 0; }
     .course { font-weight: 700; }
-
-    .date-line {
-      font-size: 11pt;
-      color: #444;
-      margin-top: 2mm;
-    }
+    .date-line { font-size: 11pt; color: #444; margin-top: 2mm; }
 
     /* Divisor */
-    .rule {
-      margin: 8mm auto;
-      border: 0;
-      border-top: .4mm solid var(--primary-light);
-      width: 70%;
-    }
+    .rule { margin: 8mm auto; border: 0; border-top: .4mm solid var(--primary-light); width: 70%; }
 
     /* Rodapé: assinatura + código/entidade */
-    .footer-table {
-      width: 100%;
-      border-collapse: collapse;
-      margin-top: 6mm;
-      font-size: 10pt;
-      color: #444;
-    }
-    .footer-table td {
-      vertical-align: top;
-      padding-top: 6mm;
-    }
+    .footer-table { width: 100%; border-collapse: collapse; margin-top: 6mm; font-size: 10pt; color: #444; }
+    .footer-table td { vertical-align: top; padding-top: 6mm; }
 
-    .sig-block {
-      text-align: center;
-      width: 55%;
-    }
-
+    .sig-block { text-align: center; width: 55%; }
     .sig-img { max-height: 16mm; display: block; margin: 0 auto 2mm auto; }
+    .sig-line { border-top: .3mm solid #999; margin: 0 auto 2mm auto; width: 70%; height: 0; }
 
-    .sig-line {
-      border-top: .3mm solid #999;
-      margin: 0 auto 2mm auto;
-      width: 70%;
-      height: 0;
-    }
-
-    .info-block {
-      text-align: right;
-      width: 45%;
-      font-size: 9.5pt;
-      line-height: 1.4;
-    }
-
+    .info-block { text-align: right; width: 45%; font-size: 9.5pt; line-height: 1.4; }
     .muted { color: #666; }
     .code  { font-family: "DejaVu Sans Mono", monospace; letter-spacing: .3px; }
 
-    @if(request()->query('preview'))
+    @if(($preview_mode ?? false) || request()->query('preview'))
     /* --- Estilos para o preview (web) --- */
     .frame {
-        top: 2vw;
-        left: 2vw;
-        right: 2vw;
-        bottom: 2vw;
-        border-width: 0.25vw;
+      top: 2vw; left: 2vw; right: 2vw; bottom: 2vw;
+      border-width: 0.25vw;
     }
     .content-area {
-        top: 2.2vw;
-        left: 2.2vw;
-        right: 2.2vw;
-        bottom: 2.2vw;
+      top: 2.2vw; left: 2.2vw; right: 2.2vw; bottom: 2.2vw;
     }
-    .vcenter-cell {
-        padding: 0 4vw;
-    }
-    .logo img {
-        max-height: 5vw;
-    }
-    .title {
-        font-size: 2.2vw;
-        margin-bottom: 0.8vw;
-    }
-    .subtitle {
-        font-size: 1vw;
-        margin-bottom: 0.8vw;
-    }
-    .intro {
-        font-size: 1vw;
-        margin-bottom: 0.6vw;
-    }
-    .name {
-        font-size: 3.2vw;
-        margin: 0.3vw 0 1vw 0;
-    }
-    .course-line {
-        font-size: 1.2vw;
-    }
-    .date-line {
-        font-size: 1vw;
-        margin-top: 0.4vw;
-    }
-    .rule {
-        margin: 2vw auto;
-        border-top-width: 0.08vw;
-        width: 70%;
-    }
-    .footer-table {
-        margin-top: 1.5vw;
-        font-size: 0.8vw;
-    }
-    .footer-table td {
-        padding-top: 1.5vw;
-    }
-    .sig-img {
-        max-height: 4vw;
-        margin: 0 auto 0.5vw auto;
-    }
-    .sig-line {
-        border-top-width: 0.05vw;
-        margin-bottom: 0.5vw;
-    }
-    .info-block {
-        font-size: 0.8vw;
-    }
-@endif
-</style>
+    .vcenter-cell { padding: 0 4vw; }
+    .logo img { max-height: 5vw; }
+    .title { font-size: 2.2vw; margin-bottom: 0.8vw; }
+    .subtitle { font-size: 1vw; margin-bottom: 0.8vw; }
+    .intro { font-size: 1vw; margin-bottom: 0.6vw; }
+    .name { font-size: 3.2vw; margin: 0.3vw 0 1vw 0; }
+    .course-line { font-size: 1.2vw; }
+    .date-line { font-size: 1vw; margin-top: 0.4vw; }
+    .rule { margin: 2vw auto; border-top-width: 0.08vw; width: 70%; }
+    .footer-table { margin-top: 1.5vw; font-size: 0.8vw; }
+    .footer-table td { padding-top: 1.5vw; }
+    .sig-img { max-height: 4vw; margin: 0 auto 0.5vw auto; }
+    .sig-line { border-top-width: 0.05vw; margin-bottom: 0.5vw; }
+    .info-block { font-size: 0.8vw; }
 
+    /* Se existir barra de ações, empurra o certificado para baixo */
+    @if($showActionBar)
+      .frame { top: calc(2vw + 72px); }
+      .content-area { top: calc(2.2vw + 72px); }
+    @endif
+    @endif
+  </style>
 </head>
-  <body>
 
-    <!-- Moldura -->
-    <div class="frame"></div>
+<body>
 
-    <!-- Área útil -->
-    <div class="content-area">
+  {{-- Barra de ações (só no modo web e quando houver public_id) --}}
+  @if($showActionBar)
+    @php
+      $shareUrl  = urlencode(url()->current());
+      $shareText = urlencode("Meu certificado: " . ($event_title ?? ''));
+    @endphp
 
-      <!-- Watermark opcional -->
-      @if(!empty($watermark))
-        <div class="watermark">{{ $watermark }}</div>
-      @endif
+    <div class="max-w-5xl mx-auto mt-6 mb-4 px-4 font-sans">
+      <div class="flex flex-wrap gap-2">
+        <a href="{{ route('certificates.public.download', $resolvedPublicId) }}"
+           class="inline-flex items-center px-3 py-2 text-sm border rounded-md no-underline hover:bg-gray-50">
+          Baixar PDF
+        </a>
 
+        <a href="https://www.linkedin.com/sharing/share-offsite/?url={{ $shareUrl }}" target="_blank" rel="noopener"
+           class="inline-flex items-center px-3 py-2 text-sm border rounded-md no-underline hover:bg-gray-50">
+          Compartilhar no LinkedIn
+        </a>
 
-      <!-- Bloco central (vertical + horizontal center) -->
-      <div class="vcenter">
-        <div class="vcenter-cell">
+        <a href="https://www.facebook.com/sharer/sharer.php?u={{ $shareUrl }}" target="_blank" rel="noopener"
+           class="inline-flex items-center px-3 py-2 text-sm border rounded-md no-underline hover:bg-gray-50">
+          Facebook
+        </a>
 
-          {{-- LOGO opcional --}}
-          @if(!empty($logoBase64))
-            <div class="logo">
-              <img src="{{ $logoBase64 }}" alt="Logo">
-            </div>
-          @endif
+        <a href="https://twitter.com/intent/tweet?url={{ $shareUrl }}&text={{ $shareText }}" target="_blank" rel="noopener"
+           class="inline-flex items-center px-3 py-2 text-sm border rounded-md no-underline hover:bg-gray-50">
+          X/Twitter
+        </a>
 
-          <h1 class="title">Certificado de Conclusão</h1>
-
-{{-- Subtítulo com o título do evento --}}
-<p class="subtitle">{{ $event_title ?? $course ?? '—' }}</p>
-
-<p class="intro">Certificamos que</p>
-<div class="name">{{ $name ?? 'Nome do participante' }}</div>
-
-@php
-  $etype  = $event_type_name ?? 'evento';
-  $inst   = $institution_name ?? config('app.name');
-  $dur    = $duration_phrase ?? null;   // ex.: "com uma carga horária total de 12 horas"
-  $when   = $date_phrase ?? null;       // ex.: "em 04/09/2025" ou "iniciado em 01/09/2025 até 05/09/2025"
-
-  // monta frase final com pontuação certa
-  $parts = array_filter([
-    "Concluiu com êxito o {$etype} " . ($event_title ?? $course ?? ''),
-    $inst ? "da {$inst}" : null,
-    $dur,
-    $when ? $when : null,
-  ]);
-  $sentence = implode(', ', $parts) . '.';
-@endphp
-
-<p class="course-line">{{ $sentence }}</p>
-
-<hr class="rule" />
-
-
-          <table class="footer-table">
-  <tr>
-    <td class="sig-block">
-      @if(!empty($signatureBase64))
-        <img class="sig-img" src="{{ $signatureBase64 }}" alt="Assinatura">
-      @endif
-      <div class="sig-line"></div>
-      <div>
-        @if(!empty($signer_name)) <strong>{{ $signer_name }}</strong><br>@endif
-        @if(!empty($signer_role)) <span class="muted">{{ $signer_role }}</span>@endif
+        <a href="https://wa.me/?text={{ $shareText }}%20{{ $shareUrl }}" target="_blank" rel="noopener"
+           class="inline-flex items-center px-3 py-2 text-sm border rounded-md no-underline hover:bg-gray-50">
+          WhatsApp
+        </a>
       </div>
-    </td>
-    <td class="info-block">
-      @if(!empty($institution_name))
-        <div><span class="muted">Entidade:</span> {{ $institution_name }}</div>
-      @endif
-      <div><span class="muted">Código de validação:</span> <span class="code">{{ $ref ?? '—' }}</span></div>
-    </td>
-  </tr>
-</table>
 
-        </div>
+      <hr class="mt-4 border-t border-gray-200">
+    </div>
+  @endif
+
+  <!-- Moldura -->
+  <div class="frame"></div>
+
+  <!-- Área útil -->
+  <div class="content-area">
+
+    <!-- Watermark opcional -->
+    @if(!empty($watermark))
+      <div class="watermark">{{ $watermark }}</div>
+    @endif
+
+    <!-- Bloco central (vertical + horizontal center) -->
+    <div class="vcenter">
+      <div class="vcenter-cell">
+
+        {{-- LOGO opcional --}}
+        @if(!empty($logoBase64))
+          <div class="logo">
+            <img src="{{ $logoBase64 }}" alt="Logo">
+          </div>
+        @endif
+
+        <h1 class="title">Certificado de Conclusão</h1>
+
+        {{-- Subtítulo com o título do evento --}}
+        <p class="subtitle">{{ $event_title ?? $course ?? '—' }}</p>
+
+        <p class="intro">Certificamos que</p>
+        <div class="name">{{ $name ?? 'Nome do participante' }}</div>
+
+        @php
+          $etype  = $event_type_name ?? 'evento';
+          $inst   = $institution_name ?? config('app.name');
+          $dur    = $duration_phrase ?? null;
+          $when   = $date_phrase ?? null;
+
+          $parts = array_filter([
+            "Concluiu com êxito o {$etype} " . ($event_title ?? $course ?? ''),
+            $inst ? "da {$inst}" : null,
+            $dur,
+            $when ? $when : null,
+          ]);
+          $sentence = implode(', ', $parts) . '.';
+        @endphp
+
+        <p class="course-line">{{ $sentence }}</p>
+
+        <hr class="rule" />
+
+        <table class="footer-table">
+          <tr>
+            <td class="sig-block">
+              @if(!empty($signatureBase64))
+                <img class="sig-img" src="{{ $signatureBase64 }}" alt="Assinatura">
+              @endif
+              <div class="sig-line"></div>
+              <div>
+                @if(!empty($signer_name)) <strong>{{ $signer_name }}</strong><br>@endif
+                @if(!empty($signer_role)) <span class="muted">{{ $signer_role }}</span>@endif
+              </div>
+            </td>
+            <td class="info-block">
+              @if(!empty($institution_name))
+                <div><span class="muted">Entidade:</span> {{ $institution_name }}</div>
+              @endif
+              <div><span class="muted">Código de validação:</span> <span class="code">{{ $ref ?? '—' }}</span></div>
+            </td>
+          </tr>
+        </table>
+
       </div>
     </div>
-  </body>
+  </div>
+
+</body>
 </html>

--- a/resources/views/certificates/public.blade.php
+++ b/resources/views/certificates/public.blade.php
@@ -1,0 +1,25 @@
+<!doctype html>
+<html lang="pt">
+<head>
+  <meta charset="utf-8">
+  <title>Certificado – {{ $cert->participant->name ?? 'Participante' }}</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  {{-- (Opcional) evitar indexação por buscadores --}}
+  <meta name="robots" content="noindex, nofollow">
+</head>
+{{-- VIEW PARA TESTE --}}
+<body style="max-width: 800px; margin: 2rem auto; font-family: system-ui, sans-serif;">
+  <h1>Certificado</h1>
+
+  <p><strong>Participante:</strong> {{ $cert->participant->name ?? '—' }}</p>
+  <p><strong>Evento:</strong> {{ $cert->event->title ?? '—' }}</p>
+  <p><strong>Referência:</strong> {{ $cert->ref }}</p>
+  <p><strong>Emitido em:</strong> {{ optional($cert->issued_at)->format('d/m/Y') }}</p>
+
+  {{-- Se você já gera o PDF e armazena num caminho, dá para mostrar um link de download aqui.
+       Se ainda não armazena, ignore essa parte por enquanto. --}}
+  @if(!empty($cert->pdf_path))
+      <p><a href="{{ Storage::url($cert->pdf_path) }}" target="_blank" rel="noopener">Baixar PDF</a></p>
+  @endif
+</body>
+</html>

--- a/resources/views/emails/certificate.blade.php
+++ b/resources/views/emails/certificate.blade.php
@@ -7,6 +7,10 @@
 <body>
     <p>Olá {{ $name }},</p>
     <p>Segue anexo o seu certificado.</p>
+
+    <p>Veja seu certificado no navegador:</p>
+    <p><a href="{{ $publicUrl }}">Abrir certificado</a></p>
+
     <p>Obrigado!</p>
 </body>
 </html>

--- a/routes/web.php
+++ b/routes/web.php
@@ -7,6 +7,8 @@ use App\Http\Controllers\ProfileController;
 use App\Http\Controllers\CertificateController;
 use App\Http\Controllers\ParticipantController;
 use App\Http\Controllers\DashboardController;
+use App\Http\Controllers\PublicCertificateController;
+
 
 Route::get('/', function () {
     return view('welcome');
@@ -64,30 +66,28 @@ Route::middleware(['auth', 'role:admin,staff'])->group(function () {
 
     // Rotas de certificados
 
-// Custom certificate form routes
-Route::get('/certificates/custom', [CertificateController::class, 'custom'])
-    ->name('certificates.custom');
+    // Custom certificate form routes
+    Route::get('/certificates/custom', [CertificateController::class, 'custom'])
+        ->name('certificates.custom');
 
-// 🔁 MUDAR DE GET → POST (precisa para enviar arquivos do form)
-Route::post('/certificates/download-custom', [CertificateController::class, 'certificateDownloadCustom'])
-    ->name('certificates.download.custom');
+    // 🔁 MUDAR DE GET → POST (precisa para enviar arquivos do form)
+    Route::post('/certificates/download-custom', [CertificateController::class, 'certificateDownloadCustom'])
+        ->name('certificates.download.custom');
 
-Route::post('/certificates/send/custom', [CertificateController::class, 'sendCustom'])
-    ->name('certificates.send.custom');
+    Route::post('/certificates/send/custom', [CertificateController::class, 'sendCustom'])
+        ->name('certificates.send.custom');
 
-// Event/participant certificate route (pode continuar assim)
-Route::get('/certificates/download/{event}/{participant}', [CertificateController::class, 'certificateDownload'])
-    ->name('certificates.download');
+    // Event/participant certificate route (pode continuar assim)
+    Route::get('/certificates/download/{event}/{participant}', [CertificateController::class, 'certificateDownload'])
+        ->name('certificates.download');
 
-Route::post('/certificates/send', [CertificateController::class, 'sendCertificate'])
-    ->name('certificates.send');
+    Route::post('/certificates/send', [CertificateController::class, 'sendCertificate'])
+        ->name('certificates.send');
 
-Route::post('/events/{event}/certificates/send-all', [CertificateController::class, 'sendAll'])
-    ->name('certificates.sendAll');
+    Route::post('/events/{event}/certificates/send-all', [CertificateController::class, 'sendAll'])
+        ->name('certificates.sendAll');
 
-Route::post('/certificates/preview-custom', [CertificateController::class, 'previewCustom'])->name('certificates.preview.custom');
-
-
+    Route::post('/certificates/preview-custom', [CertificateController::class, 'previewCustom'])->name('certificates.preview.custom');
 });
 
 // Rota TESTE fora do middleware
@@ -101,3 +101,9 @@ Route::middleware('auth')->group(function () {
 
 require __DIR__.'/auth.php';
 
+// acessar certificado público (sem login)
+Route::get('/c/{publicId}', [PublicCertificateController::class, 'show'])
+    ->name('certificates.public.show');
+
+Route::get('/c/{publicId}/download', [CertificateController::class, 'publicDownloadByPublicId'])
+    ->name('certificates.public.download');


### PR DESCRIPTION
Implementação de compartilhamento de certificado via redes sociais 

1 - Criação de novas colunas na tabela certificates:
* public_id e published_at
* Public_id será usado para gerar um link que ninguém consegue adivinhar, serve como “chave pública” para acessar a página do certificado sem login.
* published_at para marcar a data em que é decidido liberar o certificado para visualização pública.

2 - Migrações feitas

3 - A função sendCertificate no CertificateController alterado para garantir que o certificado tem identificador público e está "publicado”. 

4 - Algumas outras mudanças necessárias no CertificateController: 
sendCertificate
* Adicionado bloco para gerar public_id e published_at se não existirem.
* Passado o $certificate para o CertificateMail.
sendAll
* Mesmo bloco para gerar public_id e published_at.
* Passado o $certificate para o CertificateMail.
sendCustom
* Mesmo bloco para gerar public_id e published_at.
* Passado o $certificate para o CertificateMail.


5 - Criação de rota publica

6 -  Criação do PublicCertificateController

7 - Criação da view publica para testar o certificado 

8 - Modificação do CertificaMail, agora o construtor aceita $certificate

9 - Adicionado link no email para acessar o certificado no browser

10 - Em certificates/pdf.blade.php foi alterado o CSS de preview: @if(($preview_mode ?? false) || request()->query('preview’)), assim a mesma view pode ser usada tanto para gerar PDF quanto para exibir no navegador.

11 - No PublicCertificateController
* Criado método show($publicId) que:
    * Busca o certificado pelo public_id (e só se tiver published_at).
    * Monta os mesmos dados que buildCertificateData.
    * Passa preview_mode = true.
    * Renderiza view('certificates.pdf', $pdfData).
Resultado
* O link público (/c/{public_id}) abre diretamente o certificado em HTML (mesma aparência do PDF).
* A view certificates/public.blade.php não é mais usada.

12 - Modificações na blade pdf.blade.php para melhorar o layout. Adiciona também os botões de compartilhamento para as redes sociais, a imagem do certificado não abre junto na publicação da rede social. | Falta melhorar a responsividade dos botões da rota pública da visualização do ceritificado
