### PR TITLE
salvar e escolher emplates para os certificados

### DIFF
--- a/app/Http/Controllers/CertificateController.php
+++ b/app/Http/Controllers/CertificateController.php
@@ -9,9 +9,10 @@ use Illuminate\Support\Str;
 use Illuminate\Http\Request;
 use App\Mail\CertificateMail;
 use Spatie\LaravelPdf\Facades\Pdf;
-use Barryvdh\DomPDF\Facade\Pdf as Dompdf; // alias Dompdf
+use App\Models\CertificateTemplate;
 use Illuminate\Support\Facades\Mail;
 use Illuminate\Support\Facades\Storage;
+use Barryvdh\DomPDF\Facade\Pdf as Dompdf; // alias Dompdf
 
 class CertificateController extends Controller
 {
@@ -23,7 +24,9 @@ class CertificateController extends Controller
     public function custom()
     {
         $events = Event::with('participants')->orderBy('start_at', 'desc')->get();
-        return view('certificates.custom', compact('events'));
+        $templates = CertificateTemplate::all();
+
+        return view('certificates.custom', compact('events', 'templates'));
     }
 
     // =========================
@@ -326,6 +329,7 @@ class CertificateController extends Controller
             'institution_name' => $institutionName,
 
             // Frases calculadas para o bloco principal
+            'course_line_prefix' => $request?->input('course_line_prefix', ''), // Texto que o usuário pode definir. Por default: "Concluiu com êxito o/a..."
             'duration_phrase'  => $durationPhrase, // "com uma carga horária total de N horas"
             'date_phrase'      => $datePhrase,     // "em DD/MM/AAAA" ou "iniciado em ... até ..."
             'ref'              => $certificate->ref,

--- a/app/Http/Controllers/CertificateTemplateController.php
+++ b/app/Http/Controllers/CertificateTemplateController.php
@@ -1,0 +1,127 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\CertificateTemplate;
+use App\Models\Event;
+use Illuminate\Http\Request;
+
+class CertificateTemplateController extends Controller
+{
+    // 1. List all templates
+    public function index()
+    {
+        $templates = CertificateTemplate::all();
+        return response()->json($templates);
+    }
+
+    // 2. Store a new template
+    // Obs: Sobre os números HTTP:
+    // 201 Created → sucesso, o recurso foi criado no servidor (por isso usamos no store).
+    // 422 Unprocessable Entity → erros de validação (campos obrigatórios faltando ou inválidos).
+    // 500 Internal Server Error → erro inesperado no servidor (ex.: problema no banco, coluna inexistente, JSON mal formado, etc.).
+    // 200 OK → sucesso padrão para respostas que não criam recursos (GET, PUT, etc.).
+    public function store(Request $request)
+    {
+        try {
+            // Validação
+            $validated = $request->validate([
+                'name' => 'required|string|max:255',
+                'event_id' => 'nullable|exists:events,id',
+            ]);
+
+            // Coleta todas as opções personalizadas do certificado
+            $options = $request->only([
+                'primary_color',
+                'watermark',
+                'course_line_prefix',
+                'logo',
+                'signature',
+            ]);
+
+            // Uploads de logo e assinatura
+            if ($request->hasFile('logo')) {
+                $options['logo_path'] = $request->file('logo')->store('certificate_logos', 'public');
+            }
+
+            if ($request->hasFile('signature')) {
+                $options['signature_path'] = $request->file('signature')->store('certificate_signatures', 'public');
+            }
+
+            // Criação do template
+            $template = CertificateTemplate::create([
+                'name'    => $validated['name'],
+                'options' => $options,
+            ]);
+
+            // Se houver um evento selecionado, vincula o template
+            if (!empty($validated['event_id'])) {
+                $event = Event::find($validated['event_id']);
+                if ($event) {
+                    $event->template_id = $template->id;
+                    $event->save();
+                }
+            }
+
+            return response()->json([
+                'success' => true,
+                'template' => $template
+            ], 201);
+
+
+        } catch (\Illuminate\Validation\ValidationException $e) {
+            // Retorna erros de validação como JSON
+            return response()->json([
+                'success' => false,
+                'message' => 'Erro de validação',
+                'errors'  => $e->errors(),
+            ], 422);
+
+        } catch (\Exception $e) {
+            // Qualquer outro erro
+            return response()->json([
+                'success' => false,
+                'message' => 'Erro ao salvar o template',
+                'error'   => $e->getMessage(),
+            ], 500);
+        }
+    }
+
+
+
+    // 3. Show a template
+    public function show(CertificateTemplate $template)
+    {
+        return response()->json(json_decode($template->options, true));
+    }
+
+    // 4. Assign a template to an event
+    public function assignToEvent(Request $request, $templateId)
+    {
+        $request->validate([
+            'event_id' => 'required|exists:events,id',
+        ]);
+
+        $event = Event::findOrFail($request->event_id);
+        $event->template_id = $templateId;
+        $event->save();
+
+        return response()->json([
+            'message' => 'Template assigned to event successfully',
+            'event' => $event,
+        ]);
+    }
+
+    // 5. Unassign template from an event
+    public function unassignFromEvent($eventId)
+    {
+        $event = Event::findOrFail($eventId);
+        $event->template_id = null;
+        $event->save();
+
+        return response()->json([
+            'message' => 'Template unassigned from event successfully',
+            'event' => $event,
+        ]);
+    }
+}

--- a/app/Models/CertificateTemplate.php
+++ b/app/Models/CertificateTemplate.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class CertificateTemplate extends Model
+{
+    protected $fillable = [
+        'name',
+        'options' // json file
+    ];
+
+    protected $casts = [ // $casts transforma o arquivo json em um array
+        'options' => 'array',
+    ];
+
+
+    public function events()
+    {
+        return $this->hasMany(\App\Models\Event::class, 'template_id');
+    }
+
+}

--- a/app/Models/Event.php
+++ b/app/Models/Event.php
@@ -19,6 +19,8 @@ class Event extends Model
         'issuer_name',
         'issuer_role',
         'issuer_signature_path',
+        // referência ao template
+        'template_id',
     ];
 
     protected $casts = [
@@ -37,6 +39,12 @@ class Event extends Model
     {
         return $this->belongsTo(\App\Models\EventType::class, 'event_type_id');
     }
+
+    public function template()
+    {
+        return $this->belongsTo(CertificateTemplate::class, 'template_id');
+    }
+
 
     // facilita mostrar a imagem de assinatura na view
     public function getIssuerSignatureUrlAttribute(): ?string

--- a/database/migrations/2025_09_18_170320_create_certificate_templates_table.php
+++ b/database/migrations/2025_09_18_170320_create_certificate_templates_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('certificate_templates', function (Blueprint $table) {
+            $table->id();
+            $table->string('name'); // Template name
+            $table->json('options'); // Store customizations (frame color, logo path, etc.)
+            $table->boolean('is_default')->default(false); // Optional: mark default template
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('certificate_templates');
+    }
+};

--- a/database/migrations/2025_09_18_171126_add_template_id_to_events_table.php
+++ b/database/migrations/2025_09_18_171126_add_template_id_to_events_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('events', function (Blueprint $table) {
+             $table->foreignId('template_id')
+              ->nullable()
+              ->constrained('certificate_templates')
+              ->onDelete('set null');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('events', function (Blueprint $table) {
+              $table->dropConstrainedForeignId('template_id');
+        });
+    }
+};

--- a/resources/js/certificates.js
+++ b/resources/js/certificates.js
@@ -182,3 +182,81 @@ document.addEventListener('DOMContentLoaded', () => {
   // Primeira renderização do preview (se os selects já estiverem preenchidos)
   updatePreview();
 });
+
+
+  /* =======================
+   * 5) Mostrar e Salvar os templates
+   * ======================= */
+document.addEventListener('DOMContentLoaded', () => {
+
+  const templateSelect = document.getElementById('template_id');
+  const btnSaveTemplate = document.getElementById('btnSaveTemplate');
+  const form = document.getElementById('certificateForm');
+
+  const storeUrl = form.dataset.storeUrl; // rota para salvar o template na base de dados
+  const showBaseUrl = form.dataset.showUrl; // rota para buscar os templates da base de daods
+
+  // Save template via AJAX
+  btnSaveTemplate?.addEventListener('click', async () => {
+    const templateName = prompt('Digite um nome para o template:');
+    if (!templateName) return;
+
+    const fd = new FormData(form);
+    fd.append('name', templateName);
+
+    try {
+      const res = await fetch(storeUrl, {
+        method: 'POST',
+        headers: {
+          'X-CSRF-TOKEN': document.querySelector('input[name="_token"]').value
+        },
+        body: fd
+      });
+
+      const data = await res.json();
+      if (data.success) {
+        // Add new template to dropdown
+        const opt = document.createElement('option');
+        opt.value = data.template.id;       
+        opt.textContent = data.template.name;
+        opt.selected = true;
+        templateSelect.appendChild(opt);
+        alert('Template salvo com sucesso!');
+    } else {
+        alert(data.message || 'Erro ao salvar o template.');
+    }
+    } catch (err) {
+      console.error(err);
+      alert('Erro ao salvar o template.');
+    }
+  });
+
+  // Load template options when a template is selected
+  templateSelect?.addEventListener('change', async () => {
+    const templateId = templateSelect.value;
+    if (!templateId) return;
+
+    try {
+      const res = await fetch(`${showBaseUrl}/${templateId}`);
+      const data = await res.json();
+
+      // Populate form with saved template values
+      if (data.primary_color) document.getElementById('primary_color').value = data.primary_color;
+      if (data.watermark) document.getElementById('watermark').value = data.watermark;
+      if (data.course_line_prefix) document.getElementById('course_line_prefix').value = data.course_line_prefix;
+
+      //  FALTAM O Logo e a assinatura (podem ser tratados à parte)
+
+      // Trigger color update logic
+      const event = new Event('input', { bubbles: true });
+      document.getElementById('primary_color').dispatchEvent(event);
+
+    } catch (err) {
+      console.error(err);
+      alert('Erro ao carregar o template.');
+    }
+  });
+
+});
+
+

--- a/resources/views/certificates/custom.blade.php
+++ b/resources/views/certificates/custom.blade.php
@@ -30,12 +30,16 @@
                 @endif
 
                 {{-- FORMULÁRIO --}}
+                <!-- data-preview-url,  data-store-url e data-show-url passam as rotas
+                    para as funções no js -->
                 <form
                     id="certificateForm"
                     method="POST"
                     enctype="multipart/form-data"
                     class="space-y-6"
                     data-preview-url="{{ route('certificates.preview.custom') }}"
+                    data-store-url="{{ route('certificate-templates.store') }}"
+                    data-show-url="/certificate-templates"
                 >
                     @csrf
 
@@ -132,13 +136,14 @@
                         </p>
                         </fieldset>
 
-
+                        <!-- Logo (opcional) -->
                         <div>
                             <label class="block text-sm font-medium text-gray-700">Logo (PNG/JPG)</label>
                             <input type="file" name="logo" accept="image/png,image/jpeg" class="mt-1 block w-full text-sm">
                             <p class="mt-1 text-xs text-gray-500">Opcional. PNG com fundo transparente fica melhor.</p>
                         </div>
 
+                        <!-- Assinatura (opcional) -->
                         <div>
                             <label class="block text-sm font-medium text-gray-700">Assinatura (PNG/JPG)</label>
                             <input type="file" name="signature" accept="image/png,image/jpeg" class="mt-1 block w-full text-sm">
@@ -176,7 +181,28 @@
                         <p class="mt-1 text-xs text-gray-500">Deixe em branco para usar “pela conclusão do”.</p>
                     </div>
 
+                    <!-- Selecionar/Salvar Template -->
+                    <div class="mt-4 grid grid-cols-1 sm:grid-cols-2 gap-4">
+                        <div>
+                            <label for="template_id" class="block text-sm font-medium text-gray-700">Selecionar Template</label>
+                            <select name="template_id" id="template_id"
+                                    class="mt-1 block w-full rounded border border-gray-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-gray-900 focus:border-gray-900">
+                                <option value="">-- Nenhum --</option>
+                                @foreach($templates as $template)
+                                    <option value="{{ $template->id }}" {{ old('template_id', $event->template_id ?? '') == $template->id ? 'selected' : '' }}>
+                                        {{ $template->name }}
+                                    </option>
+                                @endforeach
+                            </select>
+                        </div>
 
+                        <div class="flex items-end gap-2">
+                            <button type="button" id="btnSaveTemplate"
+                                    class="inline-flex items-center justify-center gap-2 px-4 py-2 rounded bg-blue-600 text-white text-sm hover:bg-blue-700">
+                                Salvar como Template
+                            </button>
+                        </div>
+                    </div>
 
                     <!-- Botões -->
                     <div class="pt-2 flex flex-col sm:flex-row gap-2 sm:gap-3">

--- a/resources/views/certificates/pdf.blade.php
+++ b/resources/views/certificates/pdf.blade.php
@@ -198,8 +198,30 @@
           $dur    = $duration_phrase ?? null;
           $when   = $date_phrase ?? null;
 
+          // Checa se o título do evento já contém o tipo de evento para evitar repetição de palavras como Curso de Curso Python
+          // Use str_contains to check if the event title includes the event type name
+
+          if (str_contains(Str::lower($event_title), Str::lower($etype))) {
+            /*If it contains it, just use the event title*/
+            $mainPhrase = $event_title;
+            } else {
+            /*Otherwise, combine the event type and event title*/
+            $mainPhrase = "{$etype} " . $event_title;
+            }
+
+          /*Texto que pode ser personalisado pelo usuário*/
+          $prefix = $course_line_prefix ?? 'Concluiu com êxito o/a ';
+
+          /*monta frase final com pontuação certa
+          -> array_filter(): This function removes all empty or null values from an array.
+          -> $parts: temporary array that holds all the individual phrases to combine.
+          -> implode() takes all the elements from an array ($parts) and joins them into a single string.
+          -> The first argument, ', ', specifies the separator to use between each element.
+          -> The final . is added to the end to complete the sentence.
+          -> The complete $sentence variable is then passed to the html.*/
+
           $parts = array_filter([
-            "Concluiu com êxito o {$etype} " . ($event_title ?? $course ?? ''),
+            "{$prefix} {$mainPhrase}",
             $inst ? "da {$inst}" : null,
             $dur,
             $when ? $when : null,

--- a/resources/views/participants/view-edit-participants.blade.php
+++ b/resources/views/participants/view-edit-participants.blade.php
@@ -47,7 +47,7 @@
                                 <h3 class="text-lg font-semibold text-gray-900 truncate">{{ $event->title }}</h3>
                                     <p class="text-xs text-gray-500">
                                     {!! $event->description ? nl2br(e($event->description)) : '—' !!}
-                                    </p>                                
+                                    </p>
                                 <div class="mt-2 text-sm text-gray-600 flex flex-wrap gap-x-4 gap-y-1">
                                     <span><span class="font-medium">Tipo:</span> {{ optional($event->type)->name ?? '—' }}</span>
                                     <span><span class="font-medium">Início:</span> {{ $event->start_at->format('d/m/Y H:i') }}</span>
@@ -70,7 +70,7 @@
                         <!-- USING A TEST ROUTE TO CHECK IF THE FUNCTION IS WORKING (IT IS).
                              There must be a problem caused by the middleware/security token that is preventing
                              the original 'participants.importCsv' route to work -->
-                        <form action="/test-import-csv/{{ $event->id }}" method="POST" enctype="multipart/form-data">
+                        <form action="/import-csv/{{ $event->id }}" method="POST" enctype="multipart/form-data">
                             @csrf
                             <label class="cursor-pointer inline-flex items-center gap-2 rounded bg-purple-600 px-3 py-2 text-white text-sm hover:bg-purple-700">
                                 <svg class="w-5 h-5" fill="currentColor" aria-hidden="true"><use href="#ms-upload_file"/></svg>

--- a/routes/web.php
+++ b/routes/web.php
@@ -59,9 +59,6 @@ Route::middleware(['auth', 'role:admin,staff'])->group(function () {
         Route::delete('/participants/{participant}', [ParticipantController::class, 'detachParticipant'])
             ->name('participants.detach');
 
-        // receives a cvs file with participants and attach them all to this event
-        Route::post('/participants/import-csv', [ParticipantController::class, 'importCsv'])
-        ->name('participants.importCsv');
     });
 
     // Rotas de certificados
@@ -90,8 +87,17 @@ Route::middleware(['auth', 'role:admin,staff'])->group(function () {
     Route::post('/certificates/preview-custom', [CertificateController::class, 'previewCustom'])->name('certificates.preview.custom');
 });
 
-// Rota TESTE fora do middleware
-Route::post('/test-import-csv/{event}', [ParticipantController::class, 'importCsv']) ->name('participants.importCsvTESTE');
+// Rotas fora do middleware
+
+// Rota para importar ficheiros csv
+Route::post('/import-csv/{event}', [ParticipantController::class, 'importCsv']) ->name('participants.importCsv');
+
+// Rotas de templates
+Route::post('/certificate-templates', [CertificateTemplateController::class, 'store'])
+    ->name('certificate-templates.store');
+
+Route::get('/certificate-templates/{template}', [CertificateTemplateController::class, 'show'])
+    ->name('certificate-templates.show');
 
 Route::middleware('auth')->group(function () {
     Route::get('/profile', [ProfileController::class, 'edit'])->name('profile.edit');


### PR DESCRIPTION
mudanças na custom.blade e na pdf.blade para resolver o texto opcional; criação do dropdown para escolher templates e do botão para salvar templates. Criação da migracao/tabela de templates, do modelo e do controller de templates; alteração da função custom() no certificates controller para buscar e passar os templates para a blade; criação das rotas de templates (fora do middleware para evitar erros de autenticação); Inserção da coluna template_id na tabela eventos para podermos vincular um template a um evento.

Ainda não há funcionalidae para salvar nem o logo nem a assinatura (que são uploads de arquivos). 

E, no momento, salvar um template não funciona.... eu fico recebendo um erro que diz que o java script recebeu um HTML ao invés de um json. Amanhã vou tentar resolver isso e, se não conseguir resolver logo, vou mudar de estratégia: ao invés de tentar salvar um arquivo json (que ainda não entendo direito como funciona), vou criar mais colunas na tabela de templates para salvar as opções de customização individualmente: uma coluna para cor da moldura, uma coluna para a string da marca d'água etc