### PR TITLE
templates dentro dos eventos e botão de importar participantes

### DIFF
--- a/app/Http/Controllers/CertificateController.php
+++ b/app/Http/Controllers/CertificateController.php
@@ -57,7 +57,7 @@ class CertificateController extends Controller
         $certificate->save();
 
         // Busca o template do evento para usar suas opções
-        $template = $event->certificateTemplate;
+        $template = $event->template;
 
         // Monta dados e gera o PDF
         $pdfData = $this->buildCertificateData($event, $participant, null, $certificate, $template);
@@ -99,7 +99,7 @@ class CertificateController extends Controller
         $certificate->save();
 
         // Busca o template do evento para usar suas opções
-        $template = $event->certificateTemplate;
+        $template = $event->template;
 
         $pdfData = $this->buildCertificateData($event, $participant, null, $certificate, $template);
 
@@ -197,15 +197,23 @@ class CertificateController extends Controller
 
     public function publicDownloadByPublicId(string $publicId)
     {
-        $cert = Certificate::with(['event.type', 'participant'])
+        $cert = Certificate::with(['event.type', 'participant', 'event.template'])
             ->where('public_id', $publicId)
             ->whereNotNull('published_at')
             ->firstOrFail();
 
-        // Busca o template do evento para a geração do PDF
-        $template = $cert->event->certificateTemplate;
+        $template = $cert->event->template;
 
-        $pdfData = $this->buildCertificateData($cert->event, $cert->participant, null, $cert, $template);
+        // decodificar opções do template se existirem
+        $templateOptions = $template ? json_decode($template->options, true) : [];
+
+        $pdfData = $this->buildCertificateData(
+            $cert->event,
+            $cert->participant,
+            null,
+            $cert,
+            $templateOptions // aqui passa as opções decodificadas
+        );
 
         $pdf = \Barryvdh\DomPDF\Facade\Pdf::loadView('certificates.pdf', $pdfData)
             ->setPaper('A4', 'landscape')
@@ -262,7 +270,7 @@ class CertificateController extends Controller
         return back()->with('success', 'Certificado enviado com sucesso para ' . $request->input('email'));
     }
 
-    // Preview (HTML no iframe)
+    // Preview na custom.blade (HTML no iframe)
     public function previewCustom(Request $request)
     {
         $request->validate([
@@ -294,6 +302,40 @@ class CertificateController extends Controller
 
         return view('certificates.pdf', $pdfData);
     }
+
+    // Preview na view-edit-participnat.blade
+    public function preview(Request $request)
+    {
+        // 1. Validação dos dados de entrada
+        $request->validate([
+            'event_id'       => 'required|exists:events,id',
+            'participant_id' => 'required|exists:participants,id',
+        ]);
+
+        // 2. Busca o evento e o participante
+        $event       = Event::with('type')->findOrFail($request->input('event_id'));
+        $participant = Participant::findOrFail($request->input('participant_id'));
+
+        // 3. Busca o template associado ao evento. Se o evento não tiver um, a lógica pode usar um padrão.
+        // Assumimos que a relação 'certificateTemplate' está configurada no modelo Event.
+        $template = $event->template;
+
+        // 4. Cria ou encontra um registro de certificado para o preview
+        $certificate = Certificate::firstOrCreate(
+            ['event_id' => $event->id, 'participant_id' => $participant->id],
+            ['ref' => strtoupper(Str::random(12)), 'issued_at' => now()]
+        );
+
+        // 5. Constrói os dados para o PDF
+        // Reutiliza a sua função 'buildCertificateData' para centralizar a lógica de construção dos dados.
+        // Esta função deve ser responsável por juntar todas as informações do evento, participante e template.
+        $pdfData = $this->buildCertificateData($event, $participant, $request, $certificate, $template);
+        $pdfData['preview_mode'] = true;
+
+        // 6. Retorna a view do certificado para o preview
+        return view('certificates.pdf', $pdfData);
+    }
+
 
     // =========================
     // HELPERS
@@ -332,6 +374,9 @@ class CertificateController extends Controller
         }
 
         // Cor e watermark
+        // Expressões ternárias aninhadas são como uma sequência de blocos if/else. No caso de $primaryColor,
+        // primeiro verificamos se temos um $request e se ele contém um valor para 'primary_color'.
+        // Se não, então verificamos se temos um $template. Se não houver, $primaryColor será igual a '#000000'.  
         $primaryColor = $request && $request->filled('primary_color') ? (string)$request->input('primary_color') : ($template ? (string)$template->options['primary_color'] : '#000000');
         $watermark = $request && $request->filled('watermark') ? trim((string)$request->input('watermark')) : ($template ? (string)$template->options['watermark'] : null);
 

--- a/app/Http/Controllers/CertificateTemplateController.php
+++ b/app/Http/Controllers/CertificateTemplateController.php
@@ -121,10 +121,9 @@ class CertificateTemplateController extends Controller
         $event->template_id = $templateId;
         $event->save();
 
-        return response()->json([
-            'message' => 'Template assigned to event successfully',
-            'event' => $event,
-        ]);
+        return redirect()
+        ->back()
+        ->with('success', 'Template vinculado ao evento com sucesso.');
     }
 
     // 5. Unassign template from an event
@@ -134,9 +133,8 @@ class CertificateTemplateController extends Controller
         $event->template_id = null;
         $event->save();
 
-        return response()->json([
-            'message' => 'Template unassigned from event successfully',
-            'event' => $event,
-        ]);
+        return redirect()
+        ->back()
+        ->with('success', 'Template desvinculado ao evento com sucesso.');
     }
 }

--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -1,3 +1,31 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+
+.participant-item {
+  position: relative; /* Essencial para o posicionamento do preview flutuante */
+  cursor: pointer;
+}
+
+.floating-preview-container {
+  display: none; /* Inicia escondido */
+  position: absolute;
+  top: 0;
+  left: 100%; /* Posiciona à direita do item do participante */
+  z-index: 10;
+  padding-left: 10px;
+}
+
+.participant-item:hover .floating-preview-container {
+  display: block; /* Mostra o preview ao passar o mouse */
+}
+
+.floating-preview-frame {
+  width: 300px; /* Tamanho da janela do preview */
+  height: 150px;
+  border: 1px solid #e5e7eb;
+  border-radius: .5rem;
+  background: #fff;
+  box-shadow: 0 4px 12px rgba(0,0,0,.15);
+}

--- a/resources/js/certificates.js
+++ b/resources/js/certificates.js
@@ -2,7 +2,7 @@
 
 document.addEventListener('DOMContentLoaded', () => {
   /* =======================
-   * 1) Botão "enviar por e-mail" (em outra view)
+   * 1) Botão "enviar por e-mail" (na view view-edit-participants.blade.php, preenche o formulario coulto com os dados do participante)
    * ======================= */
   (() => {
     const emailButtons = document.querySelectorAll('[data-cert-email]');
@@ -185,7 +185,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
 
   /* =======================
-   * 5) Mostrar e Salvar os templates
+   * 5) Mostrar e Salvar os templates na custom.blade
    * ======================= */
 document.addEventListener('DOMContentLoaded', () => {
 
@@ -263,3 +263,106 @@ document.addEventListener('DOMContentLoaded', () => {
 });
 
 
+
+  /* =======================
+   * 6) Mostrar e Vincular/Descincular os templates a um evento na view-edit-participant.blade
+   * ======================= */
+document.addEventListener("DOMContentLoaded", () => {
+    // Seleciona todos os selects com data-template-select
+    const templateSelects = document.querySelectorAll("[data-template-select]");
+
+    templateSelects.forEach(select => {
+        select.addEventListener("change", function () {
+            const form = this.closest("form");
+
+            // Lê os atributos data-* do form
+            const assignBaseUrl = form.dataset.assignBaseUrl;
+            const unassignUrl   = form.dataset.unassignUrl;
+            const selectedTemplateId = this.value;
+
+            if (selectedTemplateId) {
+                // Se foi selecionado um template, define rota para "assign"
+                form.action = `${assignBaseUrl}/${selectedTemplateId}/assign-to-event`;
+                form.method = "POST";
+            } else {
+                // Se selecionou "Nenhum", define rota para "unassign"
+                form.action = unassignUrl;
+                form.method = "POST"; // poderia ser DELETE se tua rota aceitar
+            }
+
+            form.submit();
+        });
+    });
+});
+
+  /* =======================
+   * 7) Preview na view view-edit-participant.blade.php
+   * ======================= */
+
+document.addEventListener('DOMContentLoaded', () => {
+  const participantItems = document.querySelectorAll('.participant-item');
+
+  participantItems.forEach(item => {
+    const frame = item.querySelector('.floating-preview-frame');
+    const participantId = item.getAttribute('data-participant-id');
+    const eventId = item.getAttribute('data-event-id');
+    const previewUrl = item.getAttribute('data-preview-url');
+
+    let isLoaded = false;
+
+    // Função para carregar o preview
+    async function loadPreview() {
+      if (isLoaded) return; // Não recarrega se já foi carregado
+
+      try {
+        // Envia uma requisição GET ou POST para a URL do preview
+        const url = previewUrl + '?preview=1';
+        const res = await fetch(url, { method: 'POST', body: new URLSearchParams({
+          _token: document.querySelector('meta[name="csrf-token"]').content,
+          participant_id: participantId,
+          event_id: eventId
+        })});
+
+        const html = await res.text();
+        frame.srcdoc = html;
+        isLoaded = true; // Marca como carregado
+      } catch (e) {
+        console.error('Falha ao carregar o preview', e);
+      }
+    }
+
+    item.addEventListener('mouseenter', loadPreview);
+  });
+});
+
+
+
+/* =======================
+* 8) Botão de importar participnates de outro evento
+* ======================= */
+document.addEventListener('DOMContentLoaded', function () {
+    const openBtn = document.getElementById('openImportModal');
+    const closeBtn = document.getElementById('closeImportModal');
+    const cancelBtn = document.getElementById('cancelBtn');
+    const modal = document.getElementById('importModal');
+
+    if (openBtn) {
+        openBtn.addEventListener('click', () => {
+            modal.classList.remove('hidden');
+        });
+    }
+
+    [closeBtn, cancelBtn].forEach(btn => {
+        if (btn) {
+            btn.addEventListener('click', () => {
+                modal.classList.add('hidden');
+            });
+        }
+    });
+
+    window.addEventListener('click', (e) => {
+        if (e.target === modal) {
+            modal.classList.add('hidden');
+        }
+    });
+});

--- a/resources/views/certificates/pdf.blade.php
+++ b/resources/views/certificates/pdf.blade.php
@@ -98,7 +98,30 @@
       top: 2.2vw; left: 2.2vw; right: 2.2vw; bottom: 2.2vw;
     }
     .vcenter-cell { padding: 0 4vw; }
-    .logo img { max-height: 5vw; }
+    .logo {
+        margin-bottom: 6mm;
+        text-align: center; /* Adicionado para centralizar a imagem dentro da div */
+    }
+    .logo img {
+        max-height: 5vw;
+        margin: 0 auto; /* Centraliza a imagem se a div for um flexbox ou se for tratada como bloco */
+        display: block; /* Garante que a margin: auto funcione */
+    }
+
+    .watermark {
+        position: absolute;
+        top: 50%;
+        left: 50%;
+        transform: translate(-50%, -50%);
+
+        /* MODIFICAÇÕES AQUI */
+        font-size: 10vw; /* Usa uma unidade relativa (viewport width) para o tamanho da fonte */
+        white-space: nowrap; /* Evita que o texto quebre */
+
+        color: var(--primary);
+        opacity: .06;
+        pointer-events: none;
+    }
     .title { font-size: 2.2vw; margin-bottom: 0.8vw; }
     .subtitle { font-size: 1vw; margin-bottom: 0.8vw; }
     .intro { font-size: 1vw; margin-bottom: 0.6vw; }

--- a/resources/views/participants/view-edit-participants.blade.php
+++ b/resources/views/participants/view-edit-participants.blade.php
@@ -56,6 +56,46 @@
                                     <span><span class="font-medium">Instituição:</span> {{ $event->issuer_institution ?? config('app.name') ?? '—' }}</span>
                                     <span><span class="font-medium">Responsável:</span> {{ $event->issuer_name ?? '—' }}</span>
                                     <span><span class="font-medium">Cargo:</span> {{ $event->issuer_role ?? '—' }}</span>
+                                    <span class="font-medium">Template:</span>
+                                    <span>
+                                        {{-- Formulário para associar ou remover um template de um evento --}}
+                                        <form
+                                            id="event-template-form-{{ $event->id }}"
+                                            method="POST"
+                                            class="flex items-center gap-2"
+                                            data-event-id="{{ $event->id }}"
+                                            data-unassign-url="{{ route('templates.unassignFromEvent', $event->id) }}"
+                                            data-assign-base-url="{{ url('/templates') }}"
+                                        >
+                                            @csrf
+                                            {{-- Este input hidden garante que sabemos a qual evento o template será associado --}}
+                                            <input type="hidden" name="event_id" value="{{ $event->id }}">
+
+                                            <label for="template_id_{{ $event->id }}" class="sr-only">Selecionar template</label>
+
+                                            {{-- Dropdown de templates --}}
+                                            <select
+                                                name="template_id"
+                                                id="template_id_{{ $event->id }}"
+                                                class="rounded border border-gray-300 px-7 py-1 text-sm focus:outline-none focus:ring-2 focus:ring-purple-600 focus:border-purple-600"
+                                                data-template-select
+                                            >
+                                            {{-- Opção para "remover" o template associado --}}
+                                                <option value="">Nenhum</option>
+
+                                            {{-- Lista todos os templates disponíveis --}}
+                                                @foreach($templates as $template)
+                                                    <option
+                                                        value="{{ $template->id }}"
+                                                        @selected($event->template_id == $template->id)
+                                                    >
+                                                        {{ $template->name }}
+                                                    </option>
+                                                @endforeach
+                                            </select>
+                                        </form>
+                                    </span>
+
                                 </div>
                             </div>
                             <span class="shrink-0 inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium {{ $badgeClass }}">
@@ -69,12 +109,25 @@
                         <!-- upload a csv file with participants data and attachs each one of them to this event in data base -->
                         <form action="/import-csv/{{ $event->id }}" method="POST" enctype="multipart/form-data">
                             @csrf
-                            <label class="cursor-pointer inline-flex items-center gap-2 rounded bg-purple-600 px-3 py-2 text-white text-sm hover:bg-purple-700">
+                            <label class="cursor-pointer inline-flex items-center gap-2 rounded bg-purple-600 px-3 py-2 text-white text-sm hover:bg-purple-700"
+                            title="Importar participantes de um ficheiro CSV"
+                            aria-label="Importar participantes de um ficheiro csv">
                                 <svg class="w-5 h-5" fill="currentColor" aria-hidden="true"><use href="#ms-upload_file"/></svg>
-                                <span>Carregar CSV</span>
+                                <span>Carregar</span>
                                 <input type="file" name="csv_file" accept=".csv" class="hidden" onchange="this.form.submit()">
                             </label>
                         </form>
+
+                            <!-- Botão para abrir o modal que importa participantes de um outro evento existente -->
+                            <button id="openImportModal"
+                                class="inline-flex items-center gap-2 rounded px-3 py-2 text-sm bg-green-600 text-white hover:bg-green-700"
+                                title="Importar participantes de outro evento"
+                                aria-label="Importar participantes de outro evento">
+                                <svg class="w-5 h-5" fill="currentColor" aria-hidden="true" viewBox="0 -960 960 960">
+                                    <path d="M440-120v-480H120v-160q0-33 23.5-56.5T200-840h560q33 0 56.5 23.5T840-760v560q0 33-23.5 56.5T760-120H440Zm80-80h240v-160H520v160Zm0-240h240v-160H520v160ZM200-680h560v-80H200v80ZM120-80v-80h102q-48-23-77.5-68T115-330q0-79 55.5-134.5T305-520v80q-45 0-77.5 32T195-330q0 39 24 69t61 38v-97h80v240H120Z"/>
+                                </svg>
+                                <span>Importar</span>
+                            </button>
 
                         <!-- Send certificates by email to each participant button -->
                         <form action="{{ route('certificates.sendAll', $event->id) }}" method="POST">
@@ -88,9 +141,10 @@
                                 title="Enviar certificado para todos os participantes"
                                 aria-label="Enviar certificado para todos os participantes">
                                 <svg class="w-5 h-5" fill="currentColor" aria-hidden="true"><use href="#ic-mail"/></svg>
-                                <span>Enviar todos</span>
+                                <span>Enviar</span>
                             </button>
                         </form>
+
                     </div>
                 </div>
 
@@ -226,7 +280,10 @@
                     <div class="space-y-3">
                         @foreach($participants as $participant)
                             {{-- ===== Card de participante com layout 3x2 + ações verticais ===== --}}
-                            <div class="rounded-lg border border-gray-200 bg-white p-4 shadow-sm">
+                            <div class="rounded-lg border border-gray-200 bg-white p-4 shadow-sm participant-item"
+                            data-preview-url="{{ route('certificates.preview', ['participant' => $participant->id, 'event' => $event->id]) }}"
+                            data-participant-id="{{ $participant->id }}"
+                            data-event-id="{{ $event->id }}">
 
                                 <div class="grid grid-cols-1 lg:grid-cols-4 gap-4">
                                     {{-- Campos: em lg ocupam 3 colunas; 3 colunas x 2 linhas (6 campos) --}}
@@ -397,6 +454,10 @@
                                     </form>
                                 </div>
 
+                                    {{-- Floating Preview frame --}}
+                                    <div class="floating-preview-container">
+                                        <iframe class="floating-preview-frame" sandbox="allow-scripts allow-same-origin"></iframe>
+                                    </div>
                             </div>
                         @endforeach
                     </div>
@@ -414,6 +475,52 @@
                     <input type="hidden" name="event_id">
                 </form>
 
+
+                <!-- Modal -->
+                <div id="importModal" class="fixed inset-0 bg-gray-800 bg-opacity-50 flex items-center justify-center hidden">
+                    <div class="bg-white rounded-xl shadow-lg w-full max-w-md p-6 relative">
+
+                        <!-- Botão fechar (X) -->
+                        <button id="closeImportModal"
+                            class="absolute top-3 right-3 text-gray-500 hover:text-gray-700 text-xl font-bold">
+                            &times;
+                        </button>
+
+                        <h2 class="text-lg font-semibold mb-4">Importar Participantes</h2>
+
+                        <form id="importForm" method="POST" action="{{ route('participants.importFromEventSimple') }}" class="space-y-4">
+                            @csrf
+                            <input type="hidden" name="target_event_id" value="{{ $event->id }}">
+
+                            <div>
+                                <label for="source_event_id" class="block text-sm font-medium text-gray-700 mb-1">
+                                    Escolha o Evento de Origem:
+                                </label>
+                                <select name="source_event_id" id="source_event_id" required
+                                    class="w-full rounded-lg border-gray-300 focus:ring focus:ring-blue-300">
+                                    <option value="" disabled selected>-- Selecione um evento --</option>
+                                    @foreach ($events->where('id', '!=', $event->id) as $otherEvent)
+                                        <option value="{{ $otherEvent->id }}">{{ $otherEvent->title }}</option>
+                                    @endforeach
+                                </select>
+                            </div>
+
+                            <div class="flex justify-end space-x-2 pt-2">
+                                <button type="submit"
+                                    class="px-4 py-2 bg-green-600 text-white rounded-lg hover:bg-green-700">
+                                    Importar
+                                </button>
+                                <button type="button" id="cancelBtn"
+                                    class="px-4 py-2 bg-gray-400 text-white rounded-lg hover:bg-gray-500">
+                                    Cancelar
+                                </button>
+                            </div>
+                        </form>
+                    </div>
+                </div>
+
+                    </div>
+                </div>
             </div>
         </div>
     </div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -92,12 +92,19 @@ Route::middleware(['auth', 'role:admin,staff'])->group(function () {
         ->name('certificates.sendAll');
 
     Route::post('/certificates/preview-custom', [CertificateController::class, 'previewCustom'])->name('certificates.preview.custom');
+
+    Route::post('/certificates/preview-certificates', [CertificateController::class, 'preview'])->name('certificates.preview');
 });
 
 // Rotas fora do middleware
 
 // Rota para importar ficheiros csv
 Route::post('/import-csv/{event}', [ParticipantController::class, 'importCsv']) ->name('participants.importCsv');
+
+// Importar participantes de outro evento
+Route::post('/import-participants', [ParticipantController::class, 'importFromEventSimple'])
+    ->name('participants.importFromEventSimple');
+
 
 // Rotas de templates
 
@@ -109,6 +116,13 @@ Route::post('/certificate-templates', [CertificateTemplateController::class, 'st
 
 Route::get('/certificate-templates/{template}', [CertificateTemplateController::class, 'show'])
     ->name('certificate-templates.show');
+
+Route::post('/templates/{template}/assign-to-event', [CertificateTemplateController::class, 'assignToEvent'])
+    ->name('templates.assignToEvent');
+
+Route::post('/templates/unassign-from-event/{event}', [CertificateTemplateController::class, 'unassignFromEvent'])
+    ->name('templates.unassignFromEvent');
+
 
 
 Route::middleware('auth')->group(function () {


### PR DESCRIPTION
Mudanças na view-edit-participants.blade.php:

-> Agora a blade view-edit-participants tem um menu dropdown que permite escolher um template salvo e vincula-lo ao evento. E os certificados baixados e/ou enviados por esta blade agora vão também com as opções de customização certas. 

-> Tem também um preview do certificado que aparece quando o mouse passa ("hover") sobre o participante. (Obs: para resolver a janelinha do preview tive que "apelar" para um pouquinho de css). 

-> Ainda falta: solucionar o certificado gerado/recuperado pela url pública (este ainda está sem as opções de customização corretas)

-> Outra novidade: acrescentei o botão "importar participantes de outro evento" nesta blade  (e fiz a função e js correspondentes, já está funcional). Acabei mudando um pouquinho os outros dois botões ("carregar csv" e "enviar para todos") para "acomodar" mehor o novo botão, mas não sou apegado a nada esteticamente, pode "re-mudar" a vontade kkkkkk