### PR TITLE
botão apagar template na custom.blade

### DIFF
--- a/app/Http/Controllers/CertificateTemplateController.php
+++ b/app/Http/Controllers/CertificateTemplateController.php
@@ -144,4 +144,27 @@ class CertificateTemplateController extends Controller
         ->back()
         ->with('success', 'Template desvinculado ao evento com sucesso.');
     }
+
+
+    // 6. Delete a template
+    public function destroy(CertificateTemplate $template)
+    {
+        try {
+            $template->delete();
+
+            return response()->json([
+                'success' => true,
+                'message' => 'Template apagado com sucesso.'
+            ]);
+        } catch (\Exception $e) {
+            return response()->json([
+                'success' => false,
+                'message' => 'Erro ao apagar o template',
+                'error' => $e->getMessage()
+            ], 500);
+        }
+    }
+
+
+
 }

--- a/resources/js/certificates.js
+++ b/resources/js/certificates.js
@@ -442,3 +442,44 @@ document.addEventListener('DOMContentLoaded', function () {
     }
 });
 
+/* =======================
+* 10) Botão apagar template na custom.blade
+* ======================= */
+
+document.getElementById('btnDeleteTemplate')?.addEventListener('click', async function() {
+    const select = document.getElementById('template_id');
+    const templateId = select.value;
+
+    if (!templateId) {
+        alert('Selecione um template para apagar.');
+        return;
+    }
+
+    if (!confirm('Tem certeza que deseja apagar este template?')) return;
+
+    try {
+        const token = document.querySelector('meta[name="csrf-token"]').getAttribute('content');
+
+        const response = await fetch(`/certificate-templates/${templateId}`, {
+            method: 'DELETE',
+            headers: {
+                'X-CSRF-TOKEN': token,
+                'Accept': 'application/json',
+                'Content-Type': 'application/json'
+            },
+        });
+
+        const data = await response.json();
+
+        if (data.success) {
+            alert(data.message);
+            // Remove do dropdown
+            select.querySelector(`option[value="${templateId}"]`).remove();
+        } else {
+            alert(data.message || 'Erro ao apagar template.');
+        }
+    } catch (error) {
+        console.error(error);
+        alert('Erro ao apagar template.');
+    }
+});

--- a/resources/views/certificates/custom.blade.php
+++ b/resources/views/certificates/custom.blade.php
@@ -201,8 +201,16 @@
                                     class="inline-flex items-center justify-center gap-2 px-4 py-2 rounded bg-blue-600 text-white text-sm hover:bg-blue-700">
                                 Salvar como Template
                             </button>
+
+                            <!-- Botão apagar -->
+                            <button type="button" id="btnDeleteTemplate"
+                                    class="inline-flex items-center justify-center gap-2 px-4 py-2 rounded bg-red-600 text-white text-sm hover:bg-red-700">
+                                Apagar Template
+                            </button>
+
                         </div>
                     </div>
+
 
                     <!-- Botões -->
                     <!-- Obs: -> method on <form> sets the default HTTP method for the whole form.

--- a/resources/views/layouts/navigation.blade.php
+++ b/resources/views/layouts/navigation.blade.php
@@ -23,7 +23,7 @@
                         <x-nav-link :href="route('certificates.custom')" :active="request()->routeIs('certificates.*')">
                             {{ __('Gerar Certificado') }}
                         </x-nav-link>
-                        <x-nav-link :href="route('participants.index')" :active="request()->routeIs('certificates.*')">
+                        <x-nav-link :href="route('participants.index')" :active="request()->routeIs('participants.*')">
                             {{ __('Participantes') }}
                         </x-nav-link>
                     @endif

--- a/routes/web.php
+++ b/routes/web.php
@@ -123,6 +123,10 @@ Route::post('/templates/{template}/assign-to-event', [CertificateTemplateControl
 Route::post('/templates/unassign-from-event/{event}', [CertificateTemplateController::class, 'unassignFromEvent'])
     ->name('templates.unassignFromEvent');
 
+Route::delete('/certificate-templates/{template}', [CertificateTemplateController::class, 'destroy'])
+    ->name('certificate-templates.destroy');
+
+
 
 
 Route::middleware('auth')->group(function () {


### PR DESCRIPTION
Acrescentado o botão de apagar o template selecionado na custom blade, assim como a rota correspondete ('certificate-templates.destroy'), a função correspondente no CertificateTemplateController (destroy()) e o bloco de js que faz o botão funcionar 

Também consertamos o detalhe do destaque/sublinhado na Navbar (relativo à view/blade com todo so participantes)